### PR TITLE
iron/dind get rid of btrfs

### DIFF
--- a/dind/entrypoint.sh
+++ b/dind/entrypoint.sh
@@ -3,11 +3,18 @@ set -ex
 
 # modified from: https://github.com/docker-library/docker/blob/866c3fbd87e8eeed524fdf19ba2d63288ad49cd2/1.11/dind/dockerd-entrypoint.sh
 # this will run either overlay or aufs as the docker fs driver, if the OS has both, overlay is preferred.
+# rewrite overlay to use overlay2 (docker 1.12, linux >=4.x required), see https://docs.docker.com/engine/userguide/storagedriver/selectadriver/#overlay-vs-overlay2
+
+fsdriver=$(grep -Eh -w -m1 "overlay|aufs" /proc/filesystems | cut -f2)
+
+if [ $fsdriver == "overlay" ]; then
+  fsdriver="overlay2"
+fi
 
 docker daemon \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
-		--storage-driver=$(grep -Eh -w -m1 "btrfs|overlay|aufs" /proc/filesystems | cut -f2) &
+		--storage-driver=$fsdriver &
 
 # wait for daemon to initialize
 sleep 3


### PR DESCRIPTION
we gave btrfs a pretty good go at it and it's really really slow even though
it doesn't make the kernel panic or run out of inodes (i.e. it works).
overlay2 seems to work with kernel 4.7+ without causing any panics and the
inode issue seems fixed (inodes on our ebs drive with cached images is around
20% usage, about same as we have with aufs -- with 'overlay' we hit 100% inode
usage just doing `docker pull -a iron/images` so it's not really suitable for
our use case). overlay2 has been fast, docker operations for create / start
container back in ms where with btrfs it was taking on the order of minutes
(yes, seriously).

tested this on a coreos box with docker 1.10 and dind 1.12 and ubuntu with
1.12 and dind 1.12 and ubuntu boots up with aufs storage driver and coreos
with overlay2, yay.

I'll push a new `iron/dind` after this is merged.
