### PR TITLE
Make 400 errors from CreateContainer user visible.

### DIFF
--- a/drivers/docker/docker.go
+++ b/drivers/docker/docker.go
@@ -285,8 +285,10 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 				"cpu_shares": container.Config.CPUShares, "hostname": container.Config.Hostname, "name": container.Name,
 				"image": container.Config.Image, "volumes": container.Config.Volumes, "binds": container.HostConfig.Binds,
 			}).WithError(err).Error("Could not create container")
-			// TODO basically no chance that creating a container failing is a user's fault, though it may be possible
-			// via certain invalid args, tbd
+
+			if ce := containerConfigError(err); ce != nil {
+				return nil, common.UserError(fmt.Errorf("Failed to create container from task configuration '%s'", ce))
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The common cause of the container configuration being bad would be due to a bad
image, lack of command/entrypoint, bad env vars and so on. All of which are
controlled by the user.

When we change the container configuration, I'd expect to catch failures due to
that before rolling it out, and even if not, this would still let us know what
went wrong.

Example: https://hud-e.iron.io/worker/projects/5614090bf76a280006000038/tasks/582a7b727582400006fd2fe9