### PR TITLE
Actually bail out of WaitContainer when context is done.

### DIFF
--- a/drivers/docker/docker_client.go
+++ b/drivers/docker/docker_client.go
@@ -218,6 +218,7 @@ func (d *dockerWrap) WaitContainer(ctx context.Context, id string) (code int, er
 		// backup bail mechanism so this doesn't sit here forever
 		select {
 		case <-ctx.Done():
+			return -1, ctx.Err()
 		default:
 		}
 


### PR DESCRIPTION
The EOF error we were running into would transition to a non-temporary
ErrConnectionRefused (since Daemon is dead). At this point we would get stuck
in the outer loop.

Now, if Docker daemon dies, the task.Timeout context will eventually break the
loop and task can be marked as failed. Of course, this doesn't solve all
problems. I am not sure yet if the AttachToContainerNonBlocking Wait() will
automatically terminate (but I expect it to, since the socket is dead).

Ideally InspectContainer will also start failing in this case, so we can
transition the task to "error".