### PR TITLE
Ctx methods

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9ea577fb26a0cb7f5eff2f412bb9ee4ab75514625f674b6a22618e73d41f5044
-updated: 2016-10-31T17:35:55.012819798-07:00
+hash: bc40ad42f5da8390036ed5da271c2b3ef037e6b5ebcf836a5bc1b630ba8107b5
+updated: 2016-12-01T10:57:08.81176988-08:00
 imports:
 - name: github.com/amir/raidman
   version: c74861fe6a7bb8ede0a010ce4485bdbb4fc4c985
@@ -10,40 +10,44 @@ imports:
   subpackages:
   - statsd
 - name: github.com/docker/distribution
-  version: 252cc27ab1272108bfd74cf939d354db77862d93
+  version: 99cb7c0946d2f5a38015443e515dc916295064d7
   subpackages:
-  - manifest/schema1
   - context
   - digest
   - manifest
+  - manifest/schema1
   - reference
   - uuid
 - name: github.com/docker/docker
-  version: 9bd8c1d3321d1b264e84ff5fba4dc04730c264f3
+  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
   subpackages:
-  - api/types/swarm
   - opts
   - pkg/archive
   - pkg/fileutils
   - pkg/homedir
-  - pkg/stdcopy
-  - api/types/mount
-  - api/types/filters
-  - pkg/idtools
   - pkg/ioutils
+  - pkg/mflag
+  - pkg/parsers
   - pkg/pools
   - pkg/promise
+  - pkg/stdcopy
   - pkg/system
-  - pkg/longpath
-  - api/types/versions
+  - pkg/ulimit
+  - pkg/units
+  - volume
+- name: github.com/docker/engine-api
+  version: 4290f40c056686fcaa5c9caf02eac1dde9315adf
+  subpackages:
+  - types/mount
+  - types/swarm
 - name: github.com/docker/go-units
   version: f2145db703495b2e525c59662db69a7344b00bb8
 - name: github.com/docker/libtrust
   version: fa567046d9b14f6aa788882a950d69651d230b21
 - name: github.com/fsouza/go-dockerclient
-  version: 4bae70ae976745ea1cd0db139b53f83a7bcb898d
+  version: 17a01eb6718ef48332c2708c037e6f284a650dbd
 - name: github.com/golang/protobuf
-  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
+  version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -61,26 +65,24 @@ imports:
 - name: github.com/opencontainers/runc
   version: 8d505cb9dc8d665c59a7f1491bf0e2a6bd5a5319
   subpackages:
-  - libcontainer/system
   - libcontainer/user
 - name: github.com/pivotal-golang/bytefmt
   version: b12c1522f4cbb5f35861bd5dd2c39a4fa996441a
 - name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
   subpackages:
   - hooks/syslog
 - name: golang.org/x/net
   version: 4876518f9e71663000c348837735820161a42df7
   subpackages:
-  - proxy
   - context
   - context/ctxhttp
+  - proxy
 - name: golang.org/x/sys
   version: 9eef40adf05b951699605195b829612bd7b69952
   subpackages:
   - unix
   - windows
-devImports: []
 testImports:
 - name: github.com/vrischmann/envconfig
   version: 757beaaeac8d14bcc7ea3f71488d65cf45cf2eff

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: bc40ad42f5da8390036ed5da271c2b3ef037e6b5ebcf836a5bc1b630ba8107b5
-updated: 2016-12-01T10:57:08.81176988-08:00
+hash: 31273f81e8268e30026f0cbf0172777b177a3e1cccee269cb1467fb16bdfc59e
+updated: 2016-12-02T11:01:01.49149698-08:00
 imports:
 - name: github.com/amir/raidman
   version: c74861fe6a7bb8ede0a010ce4485bdbb4fc4c985
   subpackages:
   - proto
+- name: github.com/Azure/go-ansiterm
+  version: fa152c58bc15761d0200cb75fe958b89a9d4888e
+  subpackages:
+  - winterm
 - name: github.com/cactus/go-statsd-client
   version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
   subpackages:
@@ -19,33 +23,43 @@ imports:
   - reference
   - uuid
 - name: github.com/docker/docker
-  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
+  version: fddb5a7f2ab29be441bc797f7e79fffc5cc531d3
   subpackages:
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/filters
+  - api/types/mount
+  - api/types/network
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/versions
   - opts
   - pkg/archive
   - pkg/fileutils
   - pkg/homedir
+  - pkg/idtools
   - pkg/ioutils
-  - pkg/mflag
-  - pkg/parsers
+  - pkg/jsonlog
+  - pkg/jsonmessage
+  - pkg/longpath
   - pkg/pools
   - pkg/promise
   - pkg/stdcopy
   - pkg/system
-  - pkg/ulimit
-  - pkg/units
-  - volume
-- name: github.com/docker/engine-api
-  version: 4290f40c056686fcaa5c9caf02eac1dde9315adf
+  - pkg/term
+  - pkg/term/windows
+- name: github.com/docker/go-connections
+  version: 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
   subpackages:
-  - types/mount
-  - types/swarm
+  - nat
 - name: github.com/docker/go-units
   version: f2145db703495b2e525c59662db69a7344b00bb8
 - name: github.com/docker/libtrust
   version: fa567046d9b14f6aa788882a950d69651d230b21
 - name: github.com/fsouza/go-dockerclient
-  version: 17a01eb6718ef48332c2708c037e6f284a650dbd
+  version: 0d9f8ca94548b03557f0eba59b4289c7e8512c4a
 - name: github.com/golang/protobuf
   version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
   subpackages:
@@ -57,7 +71,7 @@ imports:
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/heroku/docker-registry-client
-  version: 2a2e6b9e3eed0a98d438f111ba7469744c07281d
+  version: 5636cf1ddbed886e1f34d4d54ff7bf492ca6fff2
   subpackages:
   - registry
 - name: github.com/Microsoft/go-winio
@@ -65,6 +79,7 @@ imports:
 - name: github.com/opencontainers/runc
   version: 8d505cb9dc8d665c59a7f1491bf0e2a6bd5a5319
   subpackages:
+  - libcontainer/system
   - libcontainer/user
 - name: github.com/pivotal-golang/bytefmt
   version: b12c1522f4cbb5f35861bd5dd2c39a4fa996441a

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,8 @@ import:
   version: ^3.1.0
   subpackages:
   - statsd
+- package: github.com/docker/docker
+  version: fddb5a7f2ab29be441bc797f7e79fffc5cc531d3
 - package: github.com/fsouza/go-dockerclient
   version: master
 - package: github.com/heroku/docker-registry-client


### PR DESCRIPTION
i'm waiting on https://github.com/fsouza/go-dockerclient/pull/610 to land to switch to using no timeouts + context, esp for wait since it's been the source of lots of headaches. but this fixes a couple of bugs:

if task exits with an error code we don't want to flash 'unknown error'
unless it's not 'user visible' which an exit code w/ an empty log is fine (if
the user doesn't log anything..)

we were using the long timeout for the normal client and then there was no
timeout on the long timeout, after a patch lands in fsouza we can go back to
no timeout with contexts, this patch prepares for that a little but fixes this
bug that was leading to tasks staying in run indefinitely if there were
errors. boo me

merges the transports since they can share the underlying connection pool. d'oh. it may be worth setting up the tls stuff on our docker daemon we run so that we can use http/2 too

patch in worker coming up to make use of this