### PR TITLE
Add timestamp to container name to avoid collisions.

### DIFF
--- a/drivers/docker/docker_test.go
+++ b/drivers/docker/docker_test.go
@@ -57,13 +57,13 @@ func TestRunnerDocker(t *testing.T) {
 
 	task := &taskDockerTest{"test-docker", nil, nil}
 
-	closer, err := dkr.Prepare(ctx, task)
+	cookie, err := dkr.Prepare(ctx, task)
 	if err != nil {
 		t.Fatal("Couldn't prepare task test")
 	}
-	defer closer.Close()
+	defer cookie.Close()
 
-	result, err := dkr.Run(ctx, task)
+	result, err := cookie.Run(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,13 +83,13 @@ func TestRunnerDockerStdin(t *testing.T) {
 
 	task := &taskDockerTest{"test-docker-stdin", bytes.NewBufferString(input), &output}
 
-	closer, err := dkr.Prepare(ctx, task)
+	cookie, err := dkr.Prepare(ctx, task)
 	if err != nil {
 		t.Fatal("Couldn't prepare task test")
 	}
-	defer closer.Close()
+	defer cookie.Close()
 
-	result, err := dkr.Run(ctx, task)
+	result, err := cookie.Run(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/mock/mocker.go
+++ b/drivers/mock/mocker.go
@@ -17,9 +17,6 @@ package mock
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"strings"
 
 	"github.com/iron-io/runner/drivers"
 )
@@ -32,13 +29,17 @@ type Mocker struct {
 	count int
 }
 
-func (m *Mocker) Prepare(context.Context, drivers.ContainerTask) (io.Closer, error) {
-	return ioutil.NopCloser(strings.NewReader("")), nil // dummy closer
+func (m *Mocker) Prepare(context.Context, drivers.ContainerTask) (drivers.Cookie, error) {
+	return &cookie{m}, nil
 }
 
-func (m *Mocker) Run(ctx context.Context, task drivers.ContainerTask) (drivers.RunResult, error) {
-	m.count++
-	if m.count%100 == 0 {
+type cookie struct {
+	m *Mocker
+}
+
+func (c *cookie) Run(ctx context.Context) (drivers.RunResult, error) {
+	c.m.count++
+	if c.m.count%100 == 0 {
 		return nil, fmt.Errorf("Mocker error! Bad.")
 	}
 	return &runResult{

--- a/drivers/mock/mocker.go
+++ b/drivers/mock/mocker.go
@@ -37,6 +37,8 @@ type cookie struct {
 	m *Mocker
 }
 
+func (c *cookie) Close() error { return nil }
+
 func (c *cookie) Run(ctx context.Context) (drivers.RunResult, error) {
 	c.m.count++
 	if c.m.count%100 == 0 {


### PR DESCRIPTION
Unfortunately the driver interface required some refactoring to convey the container name from Prepare() to Run().
Open to suggestions. I picked the name Cookie to avoid the *Task overloads we have. Happy to go back to drivers.Task or drivers.Request.

https://trello.com/c/XN2lAbxj/32-add-task-counter-to-container-name-as-prefix-suffix-so-that-task-with-same-id-can-run-twice-it-could-only-happen-on-prepare-fail

@rdallman @ccirello 

Once everybody is happy with this, will submit worker and functions PR to use this new style.