### PR TITLE
tail writer was panic'ing

### DIFF
--- a/common/writers.go
+++ b/common/writers.go
@@ -144,7 +144,7 @@ func NewTailLinesWriter(max int) *TailLinesWriter {
 // buffer before it is truncated.
 func (t *TailLinesWriter) Write(p []byte) (n int, err error) {
 	if t.tailCalled {
-		panic("Tail() has already been called.")
+		return 0, errors.New("Tail() has already been called.")
 	}
 
 	var afterNewLine int
@@ -192,7 +192,7 @@ func (t *TailLinesWriter) chompNewline() {
 // The returned bytes alias the buffer, the same restrictions as
 // bytes.Buffer.Bytes() apply.
 //
-// Once Tail() is called, further Write()s panic.
+// Once Tail() is called, further Write()s error.
 func (t *TailLinesWriter) Tail() []byte {
 	if !t.tailCalled {
 		t.tailCalled = true


### PR DESCRIPTION
now that wait obeys the task's context the container may still be running when
we go to tail the log (this was previously true if e.g. wait timed out but
container was still running, it just didn't happen enough to notice). tailing
the log is really just a best effort to see what's going on in there, if
another write goes in there we don't really care, but it does bring up the
point that we really should wait until the container exits for real (as we
were, mostly by coincidence and not good coding); i'm not sure how to go about
it since it could end up taking forever and at some point we need to give up,
we could pass a different context to WaitContainerWithContext that has an
extra minute onto it and it would probably cover most cases, though.

we may want to return `0, nil` so that any other writers in the chain won't
fail, either one makes sense but returning nil and not writing something just
feels wrong.

i'm also surprised that our panic-recover catcher in the gofer didn't seem to catch this, but the writes are happening in a separate thread so i get it, it just sucks that we're that susceptible to panics (and we tried to be defensive!) and the fallout is not so great, we could do some dirty tricks like catching in main and maybe just rebooting the problem gofer but idk, spitballing.