### PR TITLE
driver: added method CanExecuteFast

### DIFF
--- a/drivers/docker/docker.go
+++ b/drivers/docker/docker.go
@@ -224,6 +224,15 @@ func registryForConfig(config docker.AuthConfiguration, reg string) (*registry.R
 	return r, nil
 }
 
+func (drv *DockerDriver) CanExecuteFast(ctx context.Context, task drivers.ContainerTask) bool {
+	_, err := drv.docker.InspectImage(task.Image())
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
 func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask) (drivers.Cookie, error) {
 	var cmd []string
 	if task.Command() != "" {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -49,7 +49,7 @@ type Cookie interface {
 type Driver interface {
 	// CanExecuteFast asks the driver if that tasks can be executed Without
 	// having to pull the image from a registry
-	CanExecuteFast(ctx context.Context, task ContainerTask) error
+	CanExecuteFast(ctx context.Context, task ContainerTask) bool
 
 	// Prepare can be used in order to do any preparation that a specific driver
 	// may need to do before running the task, and can be useful to put

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -47,6 +47,10 @@ type Cookie interface {
 }
 
 type Driver interface {
+	// CanExecuteFast asks the driver if that tasks can be executed Without
+	// having to pull the image from a registry
+	CanExecuteFast(ctx context.Context, task ContainerTask) error
+
 	// Prepare can be used in order to do any preparation that a specific driver
 	// may need to do before running the task, and can be useful to put
 	// preparation that the task can recover from into (i.e. if pulling an image

--- a/drivers/mock/mocker.go
+++ b/drivers/mock/mocker.go
@@ -29,6 +29,10 @@ type Mocker struct {
 	count int
 }
 
+func (m *Mocker) CanExecuteFast(context.Context, drivers.ContainerTask) bool {
+	return true
+}
+
 func (m *Mocker) Prepare(context.Context, drivers.ContainerTask) (drivers.Cookie, error) {
 	return &cookie{m}, nil
 }


### PR DESCRIPTION
The proposition of this PR is to add a method called CanExecuteFast to the driver that provides the functionality of checking if the image is available locally (without having to pull it).
This functionality is required for cases where we need to just check if the image exists locally but not run the task.
As far as I know the `Prepare` method checks for the image but also prepares the container for execution.

@nikhilm @rdallman 