### PR TITLE
update dind to 1.12.5

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM docker:1.12.3-dind
+FROM docker:1.12.5-dind
 
 RUN apk update && apk upgrade && apk add --no-cache ca-certificates
 


### PR DESCRIPTION
hopefully will stop freezing up docker and will save us from LRT, link to
relevant comment:

https://github.com/docker/docker/issues/5618#issuecomment-266564257

i'll push a update and update the worker runner after mergy poo