### PR TITLE
update docker to 1.12.6 to patch security hole

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM docker:1.12.5-dind
+FROM docker:1.12.6-dind
 
 RUN apk update && apk upgrade && apk add --no-cache ca-certificates
 


### PR DESCRIPTION
https://github.com/docker/docker/releases/tag/v1.12.6

this could hurt if a customer got any ideas, relevant for us