### PR TITLE
update bytefmt repo url address

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pivotal-golang/bytefmt"
+	"code.cloudfoundry.org/bytefmt"
 )
 
 // A DriverCookie identifies a unique request to run a task.

--- a/glide.lock
+++ b/glide.lock
@@ -81,7 +81,7 @@ imports:
   subpackages:
   - libcontainer/system
   - libcontainer/user
-- name: github.com/pivotal-golang/bytefmt
+- name: code.cloudfoundry.org/bytefmt
   version: b12c1522f4cbb5f35861bd5dd2c39a4fa996441a
 - name: github.com/Sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
   version: master
   subpackages:
   - registry
-- package: github.com/pivotal-golang/bytefmt
+- package: code.cloudfoundry.org/bytefmt
 testImport:
 - package: github.com/vrischmann/envconfig
   version: 757beaaeac8d14bcc7ea3f71488d65cf45cf2eff


### PR DESCRIPTION
This repository should be imported as code.cloudfoundry.org/bytefmt.