### PR TITLE
Fix docker tls config

### DIFF
--- a/drivers/docker/docker_client.go
+++ b/drivers/docker/docker_client.go
@@ -69,9 +69,7 @@ func newClient(env *common.Environment) dockerClient {
 			Timeout:   10 * time.Second,
 			KeepAlive: 1 * time.Minute,
 		}).Dial,
-		TLSClientConfig: &tls.Config{
-			ClientSessionCache: tls.NewLRUClientSessionCache(8192),
-		},
+		TLSClientConfig:       client.TLSConfig,
 		TLSHandshakeTimeout:   10 * time.Second,
 		MaxIdleConnsPerHost:   512,
 		Proxy:                 http.ProxyFromEnvironment,
@@ -79,6 +77,7 @@ func newClient(env *common.Environment) dockerClient {
 		IdleConnTimeout:       90 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+	client.TLSConfig.ClientSessionCache = tls.NewLRUClientSessionCache(8192)
 
 	client.HTTPClient = &http.Client{Transport: t}
 

--- a/drivers/docker/docker_client.go
+++ b/drivers/docker/docker_client.go
@@ -77,7 +77,14 @@ func newClient(env *common.Environment) dockerClient {
 		IdleConnTimeout:       90 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	client.TLSConfig.ClientSessionCache = tls.NewLRUClientSessionCache(8192)
+
+	if client.TLSConfig != nil {
+		client.TLSConfig.ClientSessionCache = tls.NewLRUClientSessionCache(8192)
+	} else {
+		t.TLSClientConfig = &tls.Config{
+			ClientSessionCache: tls.NewLRUClientSessionCache(8192),
+		}
+	}
 
 	client.HTTPClient = &http.Client{Transport: t}
 


### PR DESCRIPTION
Hi,

I recently proposed a little fix about the docker tls config client override (#34) which was merged.

But I fogot to handle the case where docker does not create it, that's why it doesn't pass the tests.

I'm sorry for the mistake, I think that the commit [4b17ac](https://github.com/thcdrt/runner/commit/4db17acba274abcbe458b5ecb0908985031bd211) should fix it.

Thank you,