### PR TITLE
Fix tests broken after a malformed PR (#35)

### DIFF
--- a/drivers/docker/docker_client.go
+++ b/drivers/docker/docker_client.go
@@ -77,7 +77,6 @@ func newClient(env *common.Environment) dockerClient {
 		IdleConnTimeout:       90 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	client.TLSConfig.ClientSessionCache = tls.NewLRUClientSessionCache(8192)
 
 	if client.TLSConfig != nil {
 		client.TLSConfig.ClientSessionCache = tls.NewLRUClientSessionCache(8192)


### PR DESCRIPTION
Hi,

This is me again. I proposed Sunday a fix (#35) about a fix that I did on Friday (#34), but when the PR 35 was merged, it didn't apply the right commit.

Instead of applying this commit [4db17a](https://github.com/thcdrt/runner/commit/4db17acba274abcbe458b5ecb0908985031bd211), it applied this one [a40e50](https://github.com/thcdrt/runner/commit/a40e50cac924093d5768b2aaa37ac10bb9fec0f1) which broke the tests again...

I'm really sorry about that, I probably made a bad manipulation on my side.

I don't know if you can do something about it to cancel my mistakes, else you can merge this PR which should repair my last mistakes and pass the tests !

Thank you,

Thomas