### PR TITLE
Correctly handle images with dots in their names

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -273,7 +273,7 @@ func ParseImage(image string) (registry, repo, tag string) {
 	case 1:
 		repo = "library/" + repo
 	case 2:
-		if strings.Contains(repo, ".") {
+		if strings.Contains(parts[0], ".") {
 			registry = parts[0]
 			repo = parts[1]
 		}

--- a/drivers/driver_test.go
+++ b/drivers/driver_test.go
@@ -117,6 +117,8 @@ func TestParseImage(t *testing.T) {
 		"quay.com/iron/hello":                               {"quay.com", "iron/hello", "latest"},
 		"quay.com:8080/iron/hello:v2":                       {"quay.com:8080", "iron/hello", "v2"},
 		"localhost.localdomain:5000/samalba/hipache:latest": {"localhost.localdomain:5000", "samalba/hipache", "latest"},
+		"some-other.registry.com/busybox":                   {"some-other.registry.com", "busybox", "latest"},
+		"brandonmoser/meteor-node-0.10.41":                  {"", "brandonmoser/meteor-node-0.10.41", "latest"},
 	}
 
 	for in, out := range cases {


### PR DESCRIPTION
Correctly handle images with dots in their names, e.g. "brandonmoser/meteor-node-0.10.41".